### PR TITLE
Make `II_eps_min` controllable in `icestream` AD

### DIFF
--- a/include/materials/ADIceMaterialSI.h
+++ b/include/materials/ADIceMaterialSI.h
@@ -33,7 +33,7 @@ protected:
   const ADVariableGradient & _grad_velocity_z;
 
   // Finite strain rate parameter
-  const ADReal & _II_eps_min;
+  const Real & _II_eps_min;
   const ADVariableValue & _pressure;
 
   /// viscosity of the fluid (mu)

--- a/problems/icestream_ad_3d_SI.i
+++ b/problems/icestream_ad_3d_SI.i
@@ -24,6 +24,8 @@ _dt = '${fparse nb_years * 3600 * 24 * 365}'
 inlet_mph = 0.1 # 0.1 # mh-1
 inlet_mps = '${fparse inlet_mph / 3600}' # ms-1
 
+initial_II_eps_min = 1e-25
+
 # ------------------------
 
 [Mesh]
@@ -242,6 +244,7 @@ inlet_mps = '${fparse inlet_mph / 3600}' # ms-1
     pressure = "p"
     output_properties = "mu"
     outputs = "out"
+    II_eps_min = 1e-25
   []
   [ins_mat]
     type = INSADTauMaterial
@@ -253,13 +256,30 @@ inlet_mps = '${fparse inlet_mph / 3600}' # ms-1
 [Functions]
   [ocean_pressure]
     type = ParsedFunction
-    expression = 'if(z < 0, -1028 * 9.81 * z, 0)'
+    expression = 'if(z < 0, -1028 * 9.81 * z, 1e5)'
   []
   [ice_weight]
     type = ParsedFunction
     expression = '917 * 9.81 * (100 - z)'
   []
+  [viscosity_rampup]
+    type = ParsedFunction
+    expression = 'initial_II_eps_min * exp(-(t-_dt) * 1e-6)'
+    symbol_names = '_dt initial_II_eps_min'
+    symbol_values = '${_dt} ${initial_II_eps_min}'
+  []
 []
+
+
+# [Controls]
+#   [II_eps_min_control]
+#     type = RealFunctionControl
+#     parameter = 'Materials/ice/II_eps_min'
+#     function = 'viscosity_rampup'
+#     execute_on = 'initial timestep_begin'
+#   []
+# []
+
 
 [Preconditioning]
   [SMP]

--- a/problems/icestream_ad_3d_SI.i
+++ b/problems/icestream_ad_3d_SI.i
@@ -244,7 +244,6 @@ initial_II_eps_min = 1e-25
     pressure = "p"
     output_properties = "mu"
     outputs = "out"
-    II_eps_min = 1e-25
   []
   [ins_mat]
     type = INSADTauMaterial
@@ -271,14 +270,14 @@ initial_II_eps_min = 1e-25
 []
 
 
-# [Controls]
-#   [II_eps_min_control]
-#     type = RealFunctionControl
-#     parameter = 'Materials/ice/II_eps_min'
-#     function = 'viscosity_rampup'
-#     execute_on = 'initial timestep_begin'
-#   []
-# []
+[Controls]
+  [II_eps_min_control]
+    type = RealFunctionControl
+    parameter = 'Materials/ice/II_eps_min'
+    function = 'viscosity_rampup'
+    execute_on = 'initial timestep_begin'
+  []
+[]
 
 
 [Preconditioning]

--- a/src/materials/ADIceMaterialSI.C
+++ b/src/materials/ADIceMaterialSI.C
@@ -23,7 +23,7 @@ ADIceMaterialSI::validParams()
   params.addParam<ADReal>("density", 917., "Ice density"); // kgm-3
   
   // Minimum strain rate parameter
-  params.addParam<ADReal>("II_eps_min", 1e-25, "Finite strain rate parameter"); // s-1
+  params.addParam<Real>("II_eps_min", 1e-25, "Finite strain rate parameter"); // s-1
   params.declareControllable("II_eps_min"); // s-1
   
   return params;
@@ -48,7 +48,7 @@ ADIceMaterialSI::ADIceMaterialSI(const InputParameters & parameters)
     _grad_velocity_z(_mesh_dimension == 3 ? adCoupledGradient("velocity_z") : _ad_grad_zero),
 
     // Finite strain rate parameter
-    _II_eps_min(getParam<ADReal>("II_eps_min")),
+    _II_eps_min(getParam<Real>("II_eps_min")),
 
     // Mean stress
     _pressure(adCoupledValue("pressure")),

--- a/src/materials/ADIceMaterialSI.C
+++ b/src/materials/ADIceMaterialSI.C
@@ -21,9 +21,10 @@ ADIceMaterialSI::validParams()
 
   params.addParam<ADReal>("nGlen", 3., "Glen exponent");   //
   params.addParam<ADReal>("density", 917., "Ice density"); // kgm-3
-
+  
   // Minimum strain rate parameter
   params.addParam<ADReal>("II_eps_min", 1e-25, "Finite strain rate parameter"); // s-1
+  params.declareControllable("II_eps_min"); // s-1
   
   return params;
 }


### PR DESCRIPTION
To explore and potentially get away from the nullspace solution.