### PR TITLE
Extract surface stresses and damage across profile

### DIFF
--- a/problems/elastic_deformation/element_deletion/glacier_calving.i
+++ b/problems/elastic_deformation/element_deletion/glacier_calving.i
@@ -24,7 +24,16 @@
     top_right = '60 20100 60'
   []
 
-  final_generator = final_mesh
+  [refined_mesh]
+    type = RefineBlockGenerator
+    input = "final_mesh"
+    block = "1 2 255"
+    refinement = '1 1 1'
+    enable_neighbor_refinement = true
+    max_element_volume = 1e100
+  []
+
+  final_generator = refined_mesh
 
 []
 
@@ -146,7 +155,8 @@
   []
   [calving_criterion]
     type = ParsedFunction
-    value = 'if((x>18000.)&(t>0.06), 1000., -1000.)'
+    # value = 'if((x>18000.)&(t>0.06), 1000., -1000.)'
+    value = 'if((x>18000.)&(t>4.), 1000., -1000.)'
   []
 []
 
@@ -505,8 +515,8 @@
   solve_type = 'NEWTON'
   nl_rel_tol = 1e-7
   nl_abs_tol = 1e-12
-  dt = 0.02
-  end_time = 10.
+  dt = 2.0 # 0.02
+  end_time = 30.
   timestep_tolerance = 1e-6
   automatic_scaling = true
   [TimeIntegrator]
@@ -528,14 +538,18 @@
     variable = 'von_mises'
     boundary = surface
     sort_by = x
-    # contains_complete_history=true
   []
   [surface_damage]
     type = SideValueSampler
     variable = 'damage_index'
     boundary = surface
     sort_by = x
-    # contains_complete_history=true
+  []
+  [surface_stressxy]
+    type = SideValueSampler
+    variable = 'stress_xy'
+    boundary = surface
+    sort_by = x
   []
 []
 

--- a/problems/elastic_deformation/element_deletion/glacier_calving.i
+++ b/problems/elastic_deformation/element_deletion/glacier_calving.i
@@ -396,14 +396,14 @@
     eigenstrain_name = ini_stress
     block = '1 2'
   []
-  # [von_mises]
-  #   type = RankTwoInvariant
-  #   invariant = 'VonMisesStress'
-  #   property_name = von_mises
-  #   rank_two_tensor = stress
-  #   outputs = exodus
-  #   block = '1 2'
-  # []
+  [von_mises]
+    type = RankTwoInvariant
+    invariant = 'VonMisesStress'
+    property_name = von_mises
+    rank_two_tensor = stress
+    outputs = exodus
+    block = '1 2'
+  []
   [damage]
     type = IceDamage
     B = 1e-10 # arbitrary, just to keep damage well below 1
@@ -506,7 +506,7 @@
   nl_rel_tol = 1e-7
   nl_abs_tol = 1e-12
   dt = 0.02
-  end_time = 50.
+  end_time = 10.
   timestep_tolerance = 1e-6
   automatic_scaling = true
   [TimeIntegrator]
@@ -522,8 +522,26 @@
   material_coverage_check = false
 []
 
+[VectorPostprocessors]
+  [surface_vonMises]
+    type = SideValueSampler
+    variable = 'von_mises'
+    boundary = surface
+    sort_by = x
+    # contains_complete_history=true
+  []
+  [surface_damage]
+    type = SideValueSampler
+    variable = 'damage_index'
+    boundary = surface
+    sort_by = x
+    # contains_complete_history=true
+  []
+[]
+
 [Outputs]
   exodus = true
+  csv = true
   perf_graph = true
 []
 


### PR DESCRIPTION
Using `SideValueSampler` to extract element variables (here `stress_xy`, `von_mises` and `damage_index` specifically) on the surface boundary. csv files are then analyzed in Python.